### PR TITLE
Fix the order of arguments in dropdown example.

### DIFF
--- a/server/documents/modules/dropdown.html.eco
+++ b/server/documents/modules/dropdown.html.eco
@@ -2037,7 +2037,7 @@ themes      : ['Default']
         $('.dropdown')
           .dropdown({
             action: 'hide',
-            onChange: function(text, value) {
+            onChange: function(value, text, $selectedItem) {
               // custom action
             }
           })


### PR DESCRIPTION
Counterintuitively, `onChange` takes the arguments in an order different from `action`. The order was correct in the documentation but not in the example provided.