### PR TITLE
Fix the Rating initialization typo

### DIFF
--- a/server/documents/modules/rating.html.eco
+++ b/server/documents/modules/rating.html.eco
@@ -168,7 +168,7 @@ themes      : ['Default']
       <div class="code" data-type="javascript">
         $('.ui.rating')
           .rating({
-            rating: 3,
+            initialRating: 3,
             maxRating: 5
           })
         ;


### PR DESCRIPTION
On example, the rating initialization is using `initialRating ` not `rating`

And `$('.ui.rating').rating({rating:3, maxting})` is not working on my testing.