### PR TITLE
Modal 'autofocus' Setting

### DIFF
--- a/server/documents/modules/modal.html.eco
+++ b/server/documents/modules/modal.html.eco
@@ -576,6 +576,11 @@ themes      : ['Default', 'Material', 'Fixed-width']
           <td>If set to false will prevent the modal from being moved to inside the dimmer</td>
         </tr>
         <tr>
+          <td>autofocus</td>
+          <td>true</td>
+          <td>When true, the first form input inside the modal will receive focus when shown.  Set this to false to prevent this behavior.</td>
+        </tr>
+        <tr>
           <td>allowMultiple</td>
           <td>false</td>
           <td>If set to true will not close other visible modals when opening a new one</td>


### PR DESCRIPTION
Explain what 'autofocus' setting does: When set to false, it won't focus on the first form input in the modal dialog, otherwise (when true; default), it will.