### PR TITLE
Update statistic.html.eco

### DIFF
--- a/server/documents/views/statistic.html.eco
+++ b/server/documents/views/statistic.html.eco
@@ -206,7 +206,7 @@ themes      : ['Default']
       </div>
       <div class="olive statistic">
         <div class="value">
-          14
+          7
         </div>
         <div class="label">
           Olive
@@ -246,7 +246,7 @@ themes      : ['Default']
       </div>
       <div class="purple statistic">
         <div class="value">
-          22
+          23
         </div>
         <div class="label">
           Purple
@@ -262,15 +262,15 @@ themes      : ['Default']
       </div>
       <div class="brown statistic">
         <div class="value">
-          15
+          36
         </div>
         <div class="label">
-          Grey
+          Brown
         </div>
       </div>
       <div class="grey statistic">
         <div class="value">
-          15
+          49
         </div>
         <div class="label">
           Grey
@@ -284,7 +284,7 @@ themes      : ['Default']
     <div class="ui inverted segment">
       <div class="ui inverted statistic">
         <div class="value">
-          27
+          54
         </div>
         <div class="label">
           Inverted
@@ -314,7 +314,15 @@ themes      : ['Default']
           Yellow
         </div>
       </div>
-      <div class="ui green inverted statistic">
+      <div class="ui olive inverted statistic">
+        <div class="value">
+          7
+        </div>
+        <div class="label">
+          Green
+        </div>
+      </div>
+        <div class="ui green inverted statistic">
         <div class="value">
           14
         </div>
@@ -348,7 +356,7 @@ themes      : ['Default']
       </div>
       <div class="ui purple inverted statistic">
         <div class="value">
-          22
+          23
         </div>
         <div class="label">
           Purple
@@ -364,7 +372,7 @@ themes      : ['Default']
       </div>
       <div class="ui brown inverted statistic">
         <div class="value">
-          15
+          36
         </div>
         <div class="label">
           Brown
@@ -372,7 +380,7 @@ themes      : ['Default']
       </div>
       <div class="ui grey inverted statistic">
         <div class="value">
-          15
+          49
         </div>
         <div class="label">
           Grey


### PR DESCRIPTION
More fixes to statistics color variations
- `brown statistic` incorrectly labeled as "grey"
- added `inverted olive statistic`
- make variations with numbers so there are no duplicates

Note: `inverted olive statistic` needs to be implemented, see https://github.com/Semantic-Org/Semantic-UI/pull/2301

Note2: See https://github.com/Semantic-Org/Semantic-UI/pull/2300 for more olive fixes