### PR TITLE
Remove duplicate row & typo in visibility settings

### DIFF
--- a/server/documents/behaviors/visibility.html.eco
+++ b/server/documents/behaviors/visibility.html.eco
@@ -797,12 +797,7 @@ type        : 'UI Behavior'
         <tr>
           <td>type</td>
           <td>false</td>
-          <td>Set to <code>image</code> to load images when on scren. Set to <code>fixed</code> to add class name <code>fixed</code> when passed.</td>
-        </tr>
-        <tr>
-          <td>type</td>
-          <td>false</td>
-          <td>Set to <code>image</code> to load images when on scren. Set to <code>fixed</code> to add class name <code>fixed</code> when passed.</td>
+          <td>Set to <code>image</code> to load images when on screen. Set to <code>fixed</code> to add class name <code>fixed</code> when passed.</td>
         </tr>
         <tr>
           <td>initialCheck</td>


### PR DESCRIPTION
Sorry for the trivial PR but I thought this should be remedied.

Screenshot:
![visibility_type_duplicate](https://cloud.githubusercontent.com/assets/1482692/8664277/fcb8923c-29a2-11e5-8962-4211e31fe2c9.png)
