### PR TITLE
Use "UK" as country next to Union Jack

### DIFF
--- a/server/partials/examples/dropdown.html
+++ b/server/partials/examples/dropdown.html
@@ -105,7 +105,7 @@
     <div data-value="fo" class="item"><i class="fo flag"></i>Faroe Islands</div>
     <div data-value="fr" class="item"><i class="fr flag"></i>France</div>
     <div data-value="ga" class="item"><i class="ga flag"></i>Gabon</div>
-    <div data-value="gb" class="item"><i class="gb flag"></i>England</div>
+    <div data-value="gb" class="item"><i class="gb flag"></i>United Kingdom</div>
     <div data-value="gd" class="item"><i class="gd flag"></i>Grenada</div>
     <div data-value="ge" class="item"><i class="ge flag"></i>Georgia</div>
     <div data-value="gf" class="item"><i class="gf flag"></i>French Guiana</div>


### PR DESCRIPTION
England is a country inside the UK; saying "England" for all of the UK is wrong.

Given the Union Jack is the flag being flown and not the flag of England, this is what
I looked for when looking for my country in the list.

Sorry for being pedantic! Love the library btw!