### PR TITLE
change link href from absolute to relative path

### DIFF
--- a/server/documents/introduction/getting-started.html.eco
+++ b/server/documents/introduction/getting-started.html.eco
@@ -118,7 +118,7 @@ type        : 'Main'
     <h4>Include in Your HTML</h4>
     <p>Running the gulp build tools will compile css and javascript for use in your project. Just link to these files in your html.</p>
     <div class="ignored code" data-type="html" data-escape="true">
-      &lt;link rel=&quot;stylesheet&quot; type=&quot;text/css&quot; href=&quot;/semantic/dist/semantic.min.css&quot;&gt;
+      &lt;link rel=&quot;stylesheet&quot; type=&quot;text/css&quot; href=&quot;semantic/dist/semantic.min.css&quot;&gt;
       &lt;script src=&quot;semantic/dist/semantic.min.js&quot;&gt;&lt;/script&gt;
     </div>
   </div>


### PR DESCRIPTION
Relative path for the CSS should make more sense and now matches the JS/script tag.