### PR TITLE
Add two sides labeled input example

### DIFF
--- a/server/documents/elements/input.html.eco
+++ b/server/documents/elements/input.html.eco
@@ -116,7 +116,7 @@ themes      : ['Default', 'GitHub']
     </div>
   </div>
 
-  <div class="example" data-class="left labeled, left corner labeled, right corner labeled, right labeled, labeled">
+  <div class="example" data-class="left labeled, left corner labeled, right corner labeled, right labeled, both sides labeled, labeled">
     <h4 class="ui header">Labeled</h4>
     <p>An input can be formatted with a label</p>
     <div class="ui labeled input">
@@ -146,6 +146,13 @@ themes      : ['Default', 'GitHub']
       <div class="ui basic label">
         kg
       </div>
+    </div>
+  </div>
+  <div class="another example">
+    <div class="ui both sides labeled input">
+      <div class="ui label">$</div>
+      <input type="text" placeholder="Amount">
+      <div class="ui basic label">.00</div>
     </div>
   </div>
   <div class="another example">

--- a/server/documents/elements/input.html.eco
+++ b/server/documents/elements/input.html.eco
@@ -116,7 +116,7 @@ themes      : ['Default', 'GitHub']
     </div>
   </div>
 
-  <div class="example" data-class="left labeled, left corner labeled, right corner labeled, right labeled, both sides labeled, labeled">
+  <div class="example" data-class="left labeled, left corner labeled, right corner labeled, right labeled, labeled">
     <h4 class="ui header">Labeled</h4>
     <p>An input can be formatted with a label</p>
     <div class="ui labeled input">
@@ -149,7 +149,7 @@ themes      : ['Default', 'GitHub']
     </div>
   </div>
   <div class="another example">
-    <div class="ui both sides labeled input">
+    <div class="ui right labeled input">
       <div class="ui label">$</div>
       <input type="text" placeholder="Amount">
       <div class="ui basic label">.00</div>


### PR DESCRIPTION
Example for issue [#2871](https://github.com/Semantic-Org/Semantic-UI/issues/2871). Case seen [in bootstrap](http://v4-alpha.getbootstrap.com/components/forms/#exampleInputAmount)

![2015-08-27-225624_397x244_scrot](https://cloud.githubusercontent.com/assets/5768813/9538864/e861ef6a-4d0e-11e5-9fb8-2323b9ea961d.png)

Although it may not be necessary or may be replaced by the previous example...