### PR TITLE
Update form.html.eco

### DIFF
--- a/server/documents/collections/form.html.eco
+++ b/server/documents/collections/form.html.eco
@@ -1313,8 +1313,8 @@ themes      : ['Default', 'Flat', 'Chubby', 'GitHub']
     <p>Multiple fields may be inline in a row</p>
     <div class="ui form">
       <div class="inline fields">
+        <label>Phone Number</label>
         <div class="field">
-          <label>Phone Number</label>
           <input type="text" placeholder="(xxx)">
         </div>
         <div class="field">


### PR DESCRIPTION
Example for inline phone number was incorrect. I think the label should come after the inline fields class, so it would look the phone number and three boxes are all in one row