### PR TITLE
Fixed history option in pushState javascript example

### DIFF
--- a/server/documents/modules/tab.html.eco
+++ b/server/documents/modules/tab.html.eco
@@ -370,6 +370,7 @@ themes      : ['Default']
       <div class="code" data-type="javascript">
         $('.ui.menu .item')
           .tab({
+            history : true,
             historyType : 'state',
             // base url for all other path changes
             path        : '/my/base/url'


### PR DESCRIPTION
The javascript for the HTML5 pushState example needs `history : true` to enable the pushState tabbing.