### PR TITLE
Update menu.html.eco

### DIFF
--- a/server/documents/collections/menu.html.eco
+++ b/server/documents/collections/menu.html.eco
@@ -338,7 +338,7 @@ themes      : ['Default', 'Chubby', 'GitHub', 'Material']
     <div class="ui vertical menu">
       <a class="active teal item">
         Inbox
-        <div class="ui teal pointing left label">1</div>
+        <div class="ui teal left pointing label">1</div>
       </a>
       <a class="item">
         Spam


### PR DESCRIPTION
Error with ui vertical menu example - arrow was pointing up when it should be left.