### PR TITLE
Fixed Missing td for compact table example

### DIFF
--- a/server/documents/collections/table.html.eco
+++ b/server/documents/collections/table.html.eco
@@ -1970,6 +1970,7 @@ themes      : ['Default', 'Basic', 'Classic', 'GitHub']
         <tr>
           <td>John</td>
           <td>Approved</td>
+          <td>Approved</td>
           <td>None</td>
         </tr>
         <tr>


### PR DESCRIPTION
The **Compact table** example has four `<td>`s per row, the example row for "John" was missing the 3rd: `<td>Approved</td>`
From:
````
    <tr>
      <td>John</td>
      <td>Approved</td>
      <td>None</td>
    </tr>
````
To: 
````
    <tr>
      <td>John</td>
      <td>Approved</td>
      <td>Approved</td>
      <td>None</td>
    </tr>
````