### PR TITLE
Fixed a bug that icons anchor does not work well

### DIFF
--- a/server/documents/elements/icon.html.eco
+++ b/server/documents/elements/icon.html.eco
@@ -13,13 +13,13 @@ type        : 'UI Element'
 themes      : ['Default']
 ---
 
-<%- @partial('header', { tabs: { icons: 'Icons', definition: 'Definition' } }) %>
+<%- @partial('header', { tabs: { icon: 'Icons', definition: 'Definition' } }) %>
 
 <script src="/javascript/icon.js"></script>
 
 <div class="main ui container">
 
-  <div class="ui active tab" data-tab="icons">
+  <div class="ui active tab" data-tab="icon">
 
     <h2 class="ui header">Icon Set</h2>
     <p>An icon set contains an arbitrary number of glyphs</p>


### PR DESCRIPTION
In the Definition tab of the icon page(http://semantic-ui.com/elements/icon.html#/definition),
Do not move to the correct location at click the following link:
![screen_shot](https://cloud.githubusercontent.com/assets/1748326/16175578/cfdac954-362d-11e6-8d08-e403a197880a.png)

Cause had moved to the icons tab of the same name.