### PR TITLE
Update Meteor Integration Instructions

### DIFF
--- a/server/documents/introduction/integrations.html.eco
+++ b/server/documents/introduction/integrations.html.eco
@@ -30,12 +30,45 @@ type        : 'Introduction'
 
   <div class="no example">
     <h4 class="ui header">Install via Atmosphere</h4>
-    <p>Install the <a href="https://atmospherejs.com/semantic/ui">Semantic UI package</a> from atmosphere. You will need a special package less-autoprefixer, to add vendor prefixes to your LESS pipeline.</p>
+    <p>Install the <a href="https://atmospherejs.com/semantic/ui">Semantic UI package</a> from atmosphere.</p>
+    <div class="code" data-type="bash">
+      meteor add semantic:ui
+    </div>
+    <p>The next step will differ depending on what version of Meteor you are running. Continue to the section relevant to your version of Meteor.</p>
+    <h4 class="ui header">(Meteor &lt;1.3) Install less-autoprefixer package</h4>
+    <p>You will need a special package less-autoprefixer, to add vendor prefixes to your LESS pipeline.</p>
     <div class="ui ignored info message">
       Since <code>flemay:less-autoprefixer</code> compiles LESS files you don't need any other less package.
     </div>
     <div class="code" data-type="bash">
-      meteor add semantic:ui flemay:less-autoprefixer
+      meteor add flemay:less-autoprefixer
+    </div>
+    <p>Continue to the "Create a custom.semantic.json file" section</p>
+    <h4 class="ui header">(Meteor 1.3+) Install less and postcss packages</h4>
+    <p>Remove the standard-minifier-css package.</p>
+    <div class="code" data-type="bash">
+      meteor remove standard-minifier-css
+    </div>
+    <p>Install the less and postcss packages.</p>
+    <div class="code" data-type="bash">
+      meteor add less juliancwirko:postcss
+    </div>
+    <p>To configure the postcss package, add the following to your <code>package.json</code> file and save it.</p>
+    <div class="code" data-type="json">
+      {
+        "devDependencies": {
+          "autoprefixer": "^6.3.1"
+        },
+        "postcss": {
+          "plugins": {
+            "autoprefixer": {"browsers": ["last 2 versions"]}
+          }
+        }
+      }
+    </div>
+    <p>To finish setting up the postcss package, install the new autoprefixer NPM package.</p>
+    <div class="code" data-type="bash">
+      meteor npm install
     </div>
   </div>
   <div class="no example">


### PR DESCRIPTION
According to https://github.com/meteor/meteor/issues/7206#issuecomment-230332826 the flemay:less-autoprefixer package causes problems with Meteor 1.3+. He points to the Meteor Guide's suggestion of using the method I've outlined here to obtain LESS autoprefixing.

Please let me know if there are any more changes you'd like me to make. I didn't have a good way of viewing my changes visually.