### PR TITLE
Search "selectFirstResult" is false by default

### DIFF
--- a/server/documents/modules/search.html.eco
+++ b/server/documents/modules/search.html.eco
@@ -616,7 +616,7 @@ type        : 'UI Module'
         </tr>
         <tr>
           <td>selectFirstResult</td>
-          <td>true</td>
+          <td>false</td>
           <td>Whether the search should automatically select the first search result after searching</td>
         </tr>
         <tr>


### PR DESCRIPTION
Verified versions 2.2.1 and 2.2.2 and `selectFirstResult` option is setted as false by default instead of true.