### PR TITLE
dropdown doesn't work without "simple" class

### DIFF
--- a/server/documents/collections/menu.html.eco
+++ b/server/documents/collections/menu.html.eco
@@ -90,7 +90,7 @@ themes      : ['Default', 'Chubby', 'GitHub', 'Material']
   </div>
   <div class="another example">
     <div class="ui top attached menu">
-      <div class="ui dropdown icon item">
+      <div class="ui simple dropdown icon item">
         <i class="wrench icon"></i>
         <div class="menu">
           <div class="item">


### PR DESCRIPTION
I can't find any place that says I need jquery or js to use this anywhere. After adding the class "simple", it worked fine. Is there somewhere I need to go to find where it tells me which jquery functions to use?