### PR TITLE
Update search.html.eco

### DIFF
--- a/server/documents/modules/search.html.eco
+++ b/server/documents/modules/search.html.eco
@@ -621,7 +621,7 @@ type        : 'UI Module'
         </tr>
         <tr>
           <td>showNoResults</td>
-          <td>false</td>
+          <td>true</td>
           <td>Whether a "no results" message should be shown if no results are found. (These messages can be modified using the <code>template</code> object specified below)</td>
         </tr>
         <tr>


### PR DESCRIPTION
In the code base for 2.2, the default value is 
```  // whether no results errors should be shown```
``` showNoResults  : true,```

Also it will be better if we maintain legacy documentation (version wise documentation. As bootstrap does. http://bootstrapdocs.com/v2.3.1/docs/)

Since I didn't find **showNoResults** field in search.js in **Semantic UI 2.1.5 - Search** but due to documentation was trying to use it.

Its very confusing for people using older version of semantics.