### PR TITLE
Fix typo

### DIFF
--- a/server/documents/elements/list.html.eco
+++ b/server/documents/elements/list.html.eco
@@ -409,7 +409,7 @@ themes      : ['Default']
       <div class="item">
         <i class="map marker icon"></i>
         <div class="content">
-          <a class="header">Krowlewskie Jadlo</a>
+          <a class="header">Krolewskie Jadlo</a>
           <div class="description">An excellent polish restaurant, quick delivery and hearty, filling meals.</div>
         </div>
       </div>


### PR DESCRIPTION
Typo in `Krowlewskie Jadlo` title.
It should be `Krolewskie Jadlo` or even better (including Polish characters) `Królewskie Jadło`

Cheers :bowtie:
