### PR TITLE
Update the README with info found in #1324

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Then you should put `docs/` under `vendor/`, so it looks like this:
         ...
         ...
 
-Next, run the commands to build the docs:
+If you haven't run `npm install` in your `./SemanticUI` folder yet, do that now. Next, run the commands to build the docs:
 
 ```
 # "ui" can be any folder that contains the SUI build files


### PR DESCRIPTION
I cloned https://github.com/Semantic-Org/Semantic-UI/ fresh for my docs folder and had never run `npm install` in the freshly cloned folder before. Hopefully this extra sentence will help another poor lost soul like me.

[Here is the comment where I found the fix to why `gulp build-docs` wasn't working](https://github.com/Semantic-Org/Semantic-UI/issues/1324#issuecomment-64944987)