### PR TITLE
List jquery.js as prerequisite

### DIFF
--- a/server/documents/introduction/getting-started.html.eco
+++ b/server/documents/introduction/getting-started.html.eco
@@ -122,7 +122,7 @@ type        : 'Main'
 
   <div class="no example">
     <h4>Include in Your HTML</h4>
-    <p>Running the gulp build tools will compile CSS and Javascript for use in your project. Just link to these files in your HTML.</p>
+    <p>Running the gulp build tools will compile CSS and Javascript for use in your project. Just link to these files in your HTML. Make also sure you link appropriate version of jquery.js</p>
     <div class="ignored code" data-type="html" data-escape="true">
       &lt;link rel=&quot;stylesheet&quot; type=&quot;text/css&quot; href=&quot;semantic/dist/semantic.min.css&quot;&gt;
       &lt;script src=&quot;semantic/dist/semantic.min.js&quot;&gt;&lt;/script&gt;


### PR DESCRIPTION
Seems like semantic UI won't work without JQuery. It should be at least mentioned.