### PR TITLE
Update Ember CLI install instructions

### DIFF
--- a/server/documents/introduction/integrations.html.eco
+++ b/server/documents/introduction/integrations.html.eco
@@ -122,9 +122,9 @@ type        : 'Introduction'
     <h4 class="ui header">Installing via CLI</h4>
     <p>Include the library as an NPM dependency, from within an ember-cli app.</p>
 
-    <p>If you are using Ember CLI <code>0.1.5-0.2.3</code>
+    <p>If you are using Ember CLI <code>1.13-2.X</code>
     <div class="code">
-      ember install:addon semantic-ui-ember
+      ember install semantic-ui-ember
     </div>
     <p>If you are using an older version <code>< 0.1.5</code>
     <div class="code">


### PR DESCRIPTION
Ember CLI complains that you are using a deprecated comand when running `ember install:addon semantic-ui-ember`
Updated that to use the correct install command, and changed the version numbering to the same as the Ember semantic repo uses.