### PR TITLE
Removed redundant example of the wrong type in tables selectable cell

### DIFF
--- a/server/documents/collections/table.html.eco
+++ b/server/documents/collections/table.html.eco
@@ -862,34 +862,6 @@ themes      : ['Default', 'Basic', 'Classic', 'GitHub']
       </tbody>
     </table>
   </div>
-  <div class="another example">
-    <table class="ui selectable inverted table">
-      <thead>
-        <tr>
-          <th>Name</th>
-          <th>Status</th>
-          <th class="right aligned">Notes</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>John</td>
-          <td>Approved</td>
-          <td class="right aligned">None</td>
-        </tr>
-        <tr>
-          <td>Jamie</td>
-          <td>Approved</td>
-          <td class="right aligned">Requires call</td>
-        </tr>
-        <tr>
-          <td>Jill</td>
-          <td>Denied</td>
-          <td class="right aligned">None</td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
 
   <div class="example">
     <h4 class="ui header">Vertical Alignment</h4>


### PR DESCRIPTION
An extra example for selectable row was placed under selectable cell.