### PR TITLE
Changed the sentence to reference loader

### DIFF
--- a/server/documents/elements/loader.html.eco
+++ b/server/documents/elements/loader.html.eco
@@ -68,7 +68,7 @@ themes      : ['Default', 'Duo', 'Pulsar']
     <h4 class="ui header">Active</h4>
     <p>A loader can be active or visible</p>
     <div class="ui ignored info message">
-      An active dimmer may not be clearly visible without using a <a href="/modules/dimmer.html">ui dimmer</a>
+      An active loader may not be clearly visible without using a <a href="/modules/dimmer.html">ui dimmer</a>
     </div>
     <div class="ui segment">
       <div class="ui active loader"></div>


### PR DESCRIPTION
Didn't make sense to say that a dimmer may not be visible when describing the loader