### PR TITLE
Save API endpoints correctly

### DIFF
--- a/server/documents/behaviors/api.html.eco
+++ b/server/documents/behaviors/api.html.eco
@@ -44,7 +44,7 @@ type        : 'UI Behavior'
       </div>
       <p>Centrally manage your entire API making sure you aren't caught modifying urls across your codebase. Define your endpoints using an <a href="#api-actions">intuitive templating system</a> that <a href="#passing-data">automatically passes data</a> found in your UI.</p>
       <div class="ignored code" data-type="javascript">
-        var api = {
+        $.fn.api.settings.api = {
           'get followers' : '/followers/{id}?results={count}',
           'create user'   : '/create',
           'add user'      : '/add/{id}',


### PR DESCRIPTION
API endpoints should be saved in `$.fn.api.settings.api` not a global `api` variable as the docs currently suggest.