### PR TITLE
Remove duplicate line from example in icon.html.eco

### DIFF
--- a/server/documents/elements/icon.html.eco
+++ b/server/documents/elements/icon.html.eco
@@ -1635,7 +1635,6 @@ themes      : ['Default']
       <i class="mini home icon"></i>
       <i class="tiny home icon"></i>
       <i class="small home icon"></i>
-      <i class="small home icon"></i>
       <br>
       <i class="home icon"></i>
       <br>


### PR DESCRIPTION
Removing duplicate line: "&gti class="small home icon"&lt&gt/i&lt" from icon size example.