### PR TITLE
Fix Checkbox Doc

### DIFF
--- a/server/documents/modules/checkbox.html.eco
+++ b/server/documents/modules/checkbox.html.eco
@@ -554,8 +554,10 @@ themes      : ['Default', 'Colored']
     <h2 class="ui dividing header">Initializing</h2>
 
     <div class="simple example">
-      <h4 class="ui header">Checkbox</h4>
-      <p>A checkbox does not require Javascript to function.</p>
+      <h4 class="ui header">Initializing a Checkbox</h4>
+      <div class="test code">
+      $('.ui.checkbox').checkbox();
+      </div>
       <div class="ui checkbox">
         <input type="checkbox">
         <label>Label</label>


### PR DESCRIPTION
Add checkbox init code to doc.

Checkbox requires javascript to function, doesn't require for showing (Read only Checkbox).
Source: https://stackoverflow.com/questions/34702133/semantic-ui-radio-buttons-do-not-check-when-clicking-the-label