### PR TITLE
Clarify the behaviour of the 'performance' config.

### DIFF
--- a/server/documents/modules/dropdown.html.eco
+++ b/server/documents/modules/dropdown.html.eco
@@ -2908,7 +2908,7 @@ themes      : ['Default', 'GitHub', 'Material']
         <tr>
           <td>performance</td>
           <td>True</td>
-          <td>Provides standard debug output to console</td>
+          <td>Provides performance stats in console, and suppresses other debug output.</td>
         </tr>
         <tr>
           <td>verbose</td>


### PR DESCRIPTION
There was no indication in the docs that the performance option suppressed other debug output.