### PR TITLE
Update CDN Links - JSDeliver changed the link template :zap:

### DIFF
--- a/server/documents/introduction/advanced-usage.html.eco
+++ b/server/documents/introduction/advanced-usage.html.eco
@@ -107,10 +107,10 @@ type        : 'Introduction'
     <h4>CDN Releases</h4>
     <p>Individual components are available on <a href="https://www.jsdelivr.com/projects/semantic-ui">jsDelivr</a></p>
     <div class="code">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/semantic-ui/<%= @getVersion() %>/semantic.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/semantic-ui@<%= @getVersion() %>/dist/semantic.min.css">
     </div>
     <div class="code">
-    <script src="https://cdn.jsdelivr.net/semantic-ui/<%= @getVersion() %>/semantic.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/semantic-ui@<%= @getVersion() %>/dist/semantic.min.js"></script>
     </div>
     <a class="ui button" href="https://www.jsdelivr.com/projects/semantic-ui" target="_blank">View All CDN Files</a>
   </div>


### PR DESCRIPTION
Apparently JSDeliver has updated the template of link for npm repos :cry: , so I have changed the source and links for those files. :zap: 

I have reviewed also that the old versions does not fluctuate and it seems to work as a glove :boxing_glove: 

Now the links looks like: (for every version different) :nerd_face: 

- https://cdn.jsdelivr.net/npm/semantic-ui@2.2.13/dist/semantic.min.css
instead of 
- https://cdn.jsdelivr.net/semantic-ui/2.2.13/semantic.min.css