### PR TITLE
Remove duplicate entry of "form" in components (build-tools semantic.json)

### DIFF
--- a/server/documents/introduction/build-tools.html.eco
+++ b/server/documents/introduction/build-tools.html.eco
@@ -283,8 +283,7 @@ type        : 'Introduction'
         "sticky",
         "tab",
         "transition",
-        "api",
-        "form",
+        "api",        
         "state",
         "visibility"
       ],


### PR DESCRIPTION
I noticed the `form` string appears twice in the `components` list.