### PR TITLE
Fix typo

### DIFF
--- a/server/documents/elements/flag.html.eco
+++ b/server/documents/elements/flag.html.eco
@@ -6,7 +6,7 @@ elementType : 'element'
 standalone  : true
 
 title       : 'Flag'
-description : 'A flag is is used to represent a political state'
+description : 'A flag is used to represent a political state'
 type        : 'UI Element'
 
 ---


### PR DESCRIPTION
In the description, there are double 'is':

Change from:
"A flag is is used to represent a political state"

To:
"A flag is used to represent a political state"