### PR TITLE
[Dropdown] Add .inverted example

### DIFF
--- a/server/documents/modules/dropdown.html.eco
+++ b/server/documents/modules/dropdown.html.eco
@@ -999,6 +999,22 @@ themes      : ['Default', 'GitHub', 'Material']
     <h2 class="ui dividing header">Variations</h2>
 
     <div class="dropdown example">
+      <h4 class="ui header">Inverted</h4>
+      <p>A dropdown can have its colors inverted for contrast</p>
+      <div class="ui inverted segment">
+        <div class="ui inverted selection dropdown">
+          <input type="hidden" name="gender">
+            <i class="dropdown icon"></i>
+            <div class="default text">Gender</div>
+            <div class="menu">
+              <div class="item" data-value="male">Male</div>
+              <div class="item" data-value="female">Female</div>
+            </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="dropdown example">
       <h4 class="ui header">Scrolling</h4>
       <p>A dropdown can have its menu scroll</p>
       <div class="ui ignored warning message">

--- a/server/files/javascript/dropdown.js
+++ b/server/files/javascript/dropdown.js
@@ -13,6 +13,7 @@ semantic.dropdown.ready = function() {
     $simpleDropdown   = $examples.filter('.simple').find('.ui.dropdown'),
     $transitionButton = $examples.filter('.transition').find('.ui.button').first(),
     $categoryDropdown = $examples.filter('.category').find('.ui.dropdown'),
+    $inverted         = $examples.find('.inverted.segment').find('.ui.dropdown'),
     // alias
     handler
   ;
@@ -61,6 +62,9 @@ semantic.dropdown.ready = function() {
     .dropdown({
       action: 'hide'
     })
+  ;
+  $inverted
+    .dropdown()
   ;
 
 };


### PR DESCRIPTION
Added an example of `.inverted` dropdown to the dropdown variations section. https://github.com/Semantic-Org/Semantic-UI/pull/6294