### PR TITLE
Fix typo in new features page

### DIFF
--- a/server/documents/introduction/new.html.eco
+++ b/server/documents/introduction/new.html.eco
@@ -42,7 +42,7 @@ type        : 'Main'
 
       <p>Semantic UI <code>2.3</code> includes a rewrite of modal to include non-js flexbox positioning for vertical centering. No longer will you have to call <code>$('.ui.modal').modal('refresh')</code> if content height changes to recenter.</p>
 
-      <p>In addition there's a new setting <code>centerable: false</code> which makes it easier to do top aligned modals when the internal may be dynamic and you dont want content to shift vertically.</p>
+      <p>In addition there's a new setting <code>centered: false</code> which makes it easier to do top aligned modals when the internal may be dynamic and you dont want content to shift vertically.</p>
 
 
       <div class="ui special modal">


### PR DESCRIPTION
Change `centerable: false` to `centered: false`.
I have confirmed that `centered` is correct and in line with the code.