### PR TITLE
Use delegated event handler

### DIFF
--- a/server/documents/collections/message.html.eco
+++ b/server/documents/collections/message.html.eco
@@ -87,8 +87,8 @@ themes      : ['Default', 'GitHub', 'Gmail']
     <div class="warning ui ignored message">
       <p>Dismissable blocks do not automatically close when using the close icon, this behavior must be defined using Javascript, for example:</p>
       <div class="code">
-      $('.message .close')
-        .on('click', function() {
+      $(document)
+        .on('click', '.message .close', function() {
           $(this)
             .closest('.message')
             .transition('fade')


### PR DESCRIPTION
Delegated event handler means that `.message` doesn't have to exist at page load

See "Direct and delegated event handlers" on http://api.jquery.com/on/