### PR TITLE
Add missing callback arguments to Server Responses

### DIFF
--- a/server/documents/behaviors/api.html.eco
+++ b/server/documents/behaviors/api.html.eco
@@ -570,19 +570,19 @@ type        : 'UI Behavior'
               // test whether a JSON response is valid
               return response.success || false;
             },
-            onComplete: function(response) {
+            onComplete: function(response, element, xhr) {
               // always called after XHR complete
             },
-            onSuccess: function(response) {
+            onSuccess: function(response, element, xhr) {
               // valid response and response.success = true
             },
-            onFailure: function(response) {
+            onFailure: function(response, element) {
               // request failed, or valid response but response.success = false
             },
-            onError: function(errorMessage) {
+            onError: function(errorMessage, element, xhr) {
               // invalid response
             },
-            onAbort: function(errorMessage) {
+            onAbort: function(errorMessage, element, xhr) {
               // navigated to a new page, CORS issue, or user canceled request
             }
           })


### PR DESCRIPTION
Completed from https://semantic-ui.com/behaviors/api.html#/settings.
At the moment it appears that `onSuccess` does not receive `xhr`. I realise that the 'Usage' section isn't designed to be the full documentation but it's a simple change