### PR TITLE
solving issue #5554

### DIFF
--- a/server/documents/usage/theming.html.eco
+++ b/server/documents/usage/theming.html.eco
@@ -44,7 +44,7 @@ type        : 'Usage'
     <h4>Recreating GitHub</h4>
     <p>Semantic UI includes an <a target="_blank" href="http://semantic-org.github.io/example-github/">example project</a> designed to showcase theming. This project includes examples of creating a packaged theme, using component CSS overrides, and managing your themes with <code>theme.config</code>.</p>
 
-    <p>To get started click <b>the paint can</b> icon next to the notification button in the top right</p>
+    <p>To get started click <b>the paint can</b> icon <img src="https://user-images.githubusercontent.com/5531204/48768246-f1d1db80-ecb8-11e8-8f25-44a582b98c77.png" /> next to the notification button in the top right of the github project page.</p>
 
     <p>The example project includes two HTML files, <code>index.html</code> is designed to swap themes using a sidebar, and uses precompiled CSS. <code>static.html</code> uses files outputted by Semantic UI and can be used alongside our <a href="/introduction/build-tools.html">gulp pipeline</a> to try modifying themes hands on.</p>
 


### PR DESCRIPTION
Solving [Semantic-Org/Semantic-UI] Doc's theming example project link broken (#5554).

It wasn't clear why the theming link to try it out was sending me to the project page on github. Now it should be clear. 

I was not able to check how it looks in html...