### PR TITLE
Adjusted z-index for ad placement so theme dropdown is visible

### DIFF
--- a/server/files/stylesheets/docs.css
+++ b/server/files/stylesheets/docs.css
@@ -2191,7 +2191,7 @@ code .chunk {
 
 #semantic-sponsor {
   position: relative;
-  z-index: 3;
+  z-index: 2;
   margin-top: -1px;
   min-height: 40px;
   border-top: solid 1px #dddddd;


### PR DESCRIPTION
When changing themes via the dropdown the sponsor ad placement always covers the menu.