### PR TITLE
Working bash example for adding custom.semantic.json

### DIFF
--- a/server/documents/introduction/integrations.html.eco
+++ b/server/documents/introduction/integrations.html.eco
@@ -73,6 +73,7 @@ type        : 'Introduction'
     <h4 class="ui header">Create a custom.semantic.json file</h4>
     <p>With meteor stopped:</>
     <div class="code" data-type="bash">
+      mkdir client/lib/semantic-ui
       touch client/lib/semantic-ui/custom.semantic.json
     </div>
     <p><code>custom.semantic.json</code> is a special file used to determine which themes and components to include in your project's build.</p>


### PR DESCRIPTION
Hi.

The meteor integration docs do not mention creating the folder `client/lib/semantic-ui` so the below bash sample does not work and is confusing to the reader. This resolves it.

Cheers