### PR TITLE
docs.css update

### DIFF
--- a/server/files/stylesheets/docs.css
+++ b/server/files/stylesheets/docs.css
@@ -230,7 +230,7 @@ blockquote .author {
 
 #example .masthead.segment {
   position: relative;
-  z-index: 3;
+  z-index: 4;
   margin: 0em;
   min-height: 185px;
   padding: 3em 0em;


### PR DESCRIPTION
z-index increased because the z-index of both the section ( #example .masthead.segment ) and the adjacent section ( #semantic-sponsor ) in the links like https://semantic-ui.com/views/card.html where there is theme select option, there the dropdown gets hidden behind the #semantic sponsor section so we arent able to access the themes for selection.