### PR TITLE
Clarify that dimmer.settings.closable is boolean

### DIFF
--- a/server/documents/modules/dimmer.html.eco
+++ b/server/documents/modules/dimmer.html.eco
@@ -469,7 +469,7 @@ themes      : ['Default']
         <tr>
           <td>closable</td>
           <td class="six wide">auto</td>
-          <td>Whether clicking on the dimmer should hide the dimmer (Defaults to <code>auto</code>, closable only when <code>settings.on</code> is not <code>hover</code></td>
+          <td>Whether clicking on the dimmer should hide the dimmer. (Defaults to <code>auto</code>, closable only when <code>settings.on</code> is not <code>hover</code>). Can also take values of <code>true</code> or <code>false</code> to allow or prevent click from dismissing the dimmer, respectively.</td>
         </tr>
         <tr>
           <td>on</td>


### PR DESCRIPTION
The documentation simply states that `closable` has a default of `auto` but doesn't state what other values it can take; I had to [check the code](https://github.com/Semantic-Org/Semantic-UI/blob/master/src/definitions/modules/dimmer.js#L364) to see that it's actually a boolean with logic to account for an `auto` flag. This change updates the docs to reflect this more clearly.